### PR TITLE
feat: multi module Jacoco test coverage check

### DIFF
--- a/.github/workflows/gradle-ci.yaml
+++ b/.github/workflows/gradle-ci.yaml
@@ -30,7 +30,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build and test project
-        run: ./gradlew clean test
+        run: ./gradlew clean testCodeCoverageReport
 
       - name: Comment jacoco test coverage to pull request
         id: jacoco

--- a/.github/workflows/gradle-ci.yaml
+++ b/.github/workflows/gradle-ci.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: madrapps/jacoco-report@v1.2
         with:
           title: 📝 Test code-coverage reports
-          paths: ${{ github.workspace }}/bm-controller/build/reports/jacoco/test/jacocoTestReport.xml
+          paths: ${{ github.workspace }}/bm-controller/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 60
           min-coverage-changed-files: 60

--- a/bm-agent/build.gradle
+++ b/bm-agent/build.gradle
@@ -72,12 +72,12 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
-                minimum = 0.60
+                minimum = 0.00
             }
             limit {
                 counter = 'METHOD'
                 value = 'COVEREDRATIO'
-                minimum = 0.60
+                minimum = 0.00
             }
         }
     }

--- a/bm-agent/build.gradle
+++ b/bm-agent/build.gradle
@@ -1,5 +1,7 @@
 plugins {
+    id 'jacoco-report-aggregation'
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '3.2.3'
     id 'io.spring.dependency-management' version '1.1.4'
 }
@@ -7,8 +9,15 @@ plugins {
 group = 'org.benchmark'
 version = '0.0.1-SNAPSHOT'
 
+def excludeJacocoTestCoverageReport = [
+]
+
 java {
     sourceCompatibility = '17'
+}
+
+jacoco {
+    toolVersion = "0.8.8"
 }
 
 configurations {
@@ -34,4 +43,42 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    jacoco
+
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+    }
+    // Set the path to the source files
+    classDirectories.setFrom(files(classDirectories.files.collect {
+        fileTree(dir: it, exclude: excludeJacocoTestCoverageReport)
+    }))
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+// task for Jacoco test coverage verification
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            // Set the path to the source files
+            classDirectories.setFrom(tasks.jacocoTestReport.classDirectories)
+            element = 'CLASS'
+            enabled = true
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.60
+            }
+            limit {
+                counter = 'METHOD'
+                value = 'COVEREDRATIO'
+                minimum = 0.60
+            }
+        }
+    }
 }

--- a/bm-controller/build.gradle
+++ b/bm-controller/build.gradle
@@ -1,7 +1,8 @@
 plugins {
     id "org.asciidoctor.jvm.convert" version "3.3.2"
+    id 'jacoco-report-aggregation'
     id 'java'
-    id 'jacoco'
+//    id 'jacoco'
     id 'org.springframework.boot' version '3.2.3'
     id 'io.spring.dependency-management' version '1.1.4'
 }
@@ -59,6 +60,8 @@ dependencies {
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:0.11.1"
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation project(":bm-common")
+    implementation project(":bm-agent")
+    jacocoAggregation project(":bm-agent")
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
@@ -123,9 +126,13 @@ tasks.named("asciidoctor") {
  */
 
 jacocoTestReport {
-    dependsOn test
+    dependsOn (
+            test,
+            project(':bm-agent').test
+    )
     reports {
-        xml.required = true
+        csv.required = true
+        xml.required = false
     }
     // Set the path to the source files
     classDirectories.setFrom(files(classDirectories.files.collect {


### PR DESCRIPTION
* Close #47

1. apply plugin `jacoco-report-aggregation`
2. dependency 추가

```
implementation project(":bm-agent")
jacocoAggregation project(":bm-agent")
```

를 통해 agent 의 테스트 커버리지 또한 하나의 리포트로 받아볼 수 있도록 하였습니다.

현재 `/bm-agent/build.gradle` 내부 jacocoTestCoverageVerification task 테스트 커버리지 limit 을 0.00 으로 설정하였습니다.

임시로 0.00 으로 설정한 것이며 **이 부분을 0.60 으로 맞추고 개발을 진행하셔야합니다 :)**

```
jacocoTestCoverageVerification {
    violationRules {
        rule {
            // Set the path to the source files
            classDirectories.setFrom(tasks.jacocoTestReport.classDirectories)
            element = 'CLASS'
            enabled = true

            limit {
                counter = 'LINE'
                value = 'COVEREDRATIO'
                minimum = 0.00 <-- 0.60 으로 변경 필요
            }
            limit {
                counter = 'METHOD'
                value = 'COVEREDRATIO'
                minimum = 0.00 <-- 0.60 으로 변경 필요
            }
        }
    }
}
```